### PR TITLE
Add tentative description of CS API.

### DIFF
--- a/draft-dekater-scion-controlplane.md
+++ b/draft-dekater-scion-controlplane.md
@@ -1597,9 +1597,11 @@ enum SegmentType {
     SEGMENT_TYPE_DOWN = 2;
     // Core segment.
     SEGMENT_TYPE_CORE = 3;
-  }
+}
 
 
+// This API is exposed by the control services of core ASes expose this on the SCION dataplane and also by all
+// control services on the "intra-protocol" network.
 service SegmentLookupService {
     // Segments returns all segments that match the request.
     rpc Segments(SegmentsRequest) returns (SegmentsResponse) {}
@@ -1624,6 +1626,7 @@ message SegmentsResponse {
     map<int32, Segments> segments = 1;
 }
 
+// This API is only exposed by core ASes and only on the SCION dataplane.
 service SegmentRegistrationService {
     // SegmentsRegistration registers segments at the remote.
     rpc SegmentsRegistration(SegmentsRegistrationRequest) returns (


### PR DESCRIPTION
Documents connectRPC as the RPC protocol instead of the old gRPC/HTTP2/QUIC stack. Document service resolution minimally.

Fixes #15
