### PR TITLE
Clarify AS entry metadata and reorganize section

### DIFF
--- a/draft-dekater-scion-controlplane.md
+++ b/draft-dekater-scion-controlplane.md
@@ -895,7 +895,7 @@ The `Header` protobuf message definition is:
    }
 ~~~~
 
-The `VerificationKeyID` message contains fields:
+The `VerificationKeyID` message contains the following REQUIRED fields:
 
   - `isd_as`: The ISD-AS number of the current AS.
   - `subject_key_id`: Refers to the certificate that contains the public key needed to verify this PCB's signature.


### PR DESCRIPTION
Resolves #107 (one last point)

[Diff with main](https://author-tools.ietf.org/api/iddiff?url_1=https://scionassociation.github.io/scion-cp_I-D/draft-dekater-scion-controlplane.txt&url_2=https://scionassociation.github.io/scion-cp_I-D/as-entry-metadata/draft-dekater-scion-controlplane.txt)