### PR TITLE
New section:  renewal of Cryptographic Material

### DIFF
--- a/draft-dekater-scion-controlplane.md
+++ b/draft-dekater-scion-controlplane.md
@@ -1274,11 +1274,12 @@ The returned `trc` contains the raw TRC.
 
 ## Renewal of Cryptographic Material {#crypto-renewal}
 
-Control Services MAY renew cryptographic material for the PKI (see {{I-D.dekater-scion-pki}}) using the following protobuf messages through the `ChainRenewalService` RPC. They MAY also renew it out of band.
+To renew PKI cryptographic material (see {{I-D.dekater-scion-pki}}), Control Services MAY employ out-of-band mechanisms or utilize the `ChainRenewalService` RPC to exchange the Protobuf messages defined below.
 
 ~~~~~
 service ChainRenewalService {
-    rpc ChainRenewal(ChainRenewalRequest) returns (ChainRenewalResponse) {}
+    rpc ChainRenewal(ChainRenewalRequest) returns (
+      ChainRenewalResponse) {}
 }
 ~~~~~
 
@@ -1310,7 +1311,7 @@ message ChainRenewalResponse {
 A `ChainRenewalResponse` message includes the following fields:
 
 - `signed_response`: a legacy field that is not in use anymore and therefore is reserved.
-- `cms_signed_response`: it contains an ASN.1 DER encoded CMS SignedData structure that contains the certificate chain. The chain is the concatenation of the ASN.1 DER encoded certificates. There are exactly 2 certificates. First the AS certificate, second the CA certificate.
+- `cms_signed_response`: it contains an ASN.1 DER encoded CMS SignedData structure containing a two-certificate chain. The chain comprises the AS certificate followed by the CA certificate, both encoded in ASN.1 DER.
 
 # Deployment Considerations
 


### PR DESCRIPTION
[Diff with main](https://author-tools.ietf.org/api/iddiff?url_1=https://scionassociation.github.io/scion-cp_I-D/draft-dekater-scion-controlplane.txt&url_2=https://scionassociation.github.io/scion-cp_I-D/cert-renewal-api/draft-dekater-scion-controlplane.txt)
Resolves #172 
Cross references to this section added in PKI in https://github.com/scionassociation/scion-cppki_I-D/pull/113 


Pending questions: 
- [x] how is a CSR is authenticated in case of renewal?
- [x] Double check all fields in the text. I left some TODOs.
