### PR TITLE
Final review before publication - Nico

### DIFF
--- a/draft-dekater-scion-controlplane.md
+++ b/draft-dekater-scion-controlplane.md
@@ -1755,7 +1755,7 @@ All other values are reserved for future use.
 
 ## Checksum Calculation
 
-The checksum is the 16-bit one's complement of the one's complement sum of the entire SCMP message. This is starting with the SCMP message type field, and prepended with a "pseudo-header" consisting of the SCION address header and the Layer 4 protocol type as defined in {{I-D.dekater-scion-dataplane}} section "SCION Header Specification/Pseudo Header for Upper-Layer Checksum".
+The checksum is calculated as the 16-bit one's complement of the one's complement sum of the entire SCMP message. This is starting with the SCMP message type field, and prepended with a "pseudo-header" consisting of the SCION address header and the Layer 4 protocol type as defined in {{I-D.dekater-scion-dataplane}} section "SCION Header Specification/Pseudo Header for Upper-Layer Checksum".
 
 ## Processing Rules
 


### PR DESCRIPTION
[Wdiff with main](https://author-tools.ietf.org/api/iddiff?url_1=https://scionassociation.github.io/scion-cp_I-D/draft-dekater-scion-controlplane.txt&url_2=https://scionassociation.github.io/scion-cp_I-D/nic-final-review/draft-dekater-scion-controlplane.txt&wdiff=1)
[Wdiff with last submission](https://author-tools.ietf.org/api/iddiff?doc_1=draft-dekater-scion-controlplane&url_2=https://scionassociation.github.io/scion-cp_I-D/nic-final-review/draft-dekater-scion-controlplane.txt&wdiff=1)

Open points:

- [x] Clarify wording for SCMP checksum (continuing from #170)
   > The checksum is the 16-bit one's complement of the one's complement sum of .. 
   Might relate to [this](url) code
- [x] Clarify  if `SegmentLookupService` API is exposed by all ASes ([Slack](https://scionproto.slack.com/archives/C8ADA9CEP/p1768190263078229))
   > This API is exposed on the SCION dataplane by the control services of ~core~ ASes and exposed on the intra-domain protocol network.
- [x] understand why this field is optional  
   > - `timestamp`: Defines the signature creation timestamp. This field is OPTIONAL. 
  Explanation ---> the timestamp that counts in PCBs is the one in [SegmentInformation](https://www.ietf.org/archive/id/draft-dekater-scion-controlplane-13.html#section-2.2.1-4). Therefore timestamps in each AS entry are not necessary.
   
   