### PR TITLE
protobuf messages syntax check

### DIFF
--- a/draft-dekater-scion-controlplane.md
+++ b/draft-dekater-scion-controlplane.md
@@ -2384,6 +2384,7 @@ Changes made to drafts since ISE submission. This section is to be removed befor
 - Clarify bits in timestamps.
 - Remove  informative reference to I-D.dekater-panrg-scion-overview  and to Anapaya's ISD assignments, since they are taken over by SCION Association in 2026
 - Overall review and wording polish
+- Protobuf messages syntax check, add missing empty `PathSegmentUnsignedExtensions` message definition
 - `SegmentLookupService` RPC: clarify wording on API exposure
 - Peer entry figure 14 - make fields consistent with protobuf definitions
 - New section: Renewal of Cryptographic Material


### PR DESCRIPTION
Resolves #175 
Fixes protobuf syntax issue introduced in #172 

[Diff with main](https://author-tools.ietf.org/api/iddiff?url_1=https://scionassociation.github.io/scion-cp_I-D/draft-dekater-scion-controlplane.txt&url_2=https://scionassociation.github.io/scion-cp_I-D/protobuf-check/draft-dekater-scion-controlplane.txt)