### PR TITLE
Typos

### DIFF
--- a/draft-dekater-scion-controlplane.md
+++ b/draft-dekater-scion-controlplane.md
@@ -682,7 +682,7 @@ The information to be included in each of these fields is described below.
 ~~~
 {: #figure-7 title="Segment Information Component"}
 
-Each PCB MUST include a ``SegmentInformation`` message with basic information about the PCB. Its Protobuf message format is:
+Each PCB MUST include a `SegmentInformation` message with basic information about the PCB. Its Protobuf message format is:
 
 ~~~~
    message SegmentInformation {


### PR DESCRIPTION
- Changed "revert" to "reverse" because we are reversing (not reverting) the sequence of hops
- Removed empty lines from SCMP code tables. My personal opinion: They suggest that there is something between these numbers, but there isn't.