### PR TITLE
SCMP: remove unnecessary entries. PCB Extensions: clarify behavior in case of unknown extensions

### DIFF
--- a/draft-dekater-scion-controlplane.md
+++ b/draft-dekater-scion-controlplane.md
@@ -1061,6 +1061,8 @@ message PathSegmentExtensions {
   }
 ~~~~
 
+If a Control Service receives an unknown PCB extension, it SHOULD skip the extension, but preserve it unmodified in case the PCB is further propagated.
+
 ### PCB Validity {#pcb-validity}
 
 To be valid (that is, usable to construct a valid path), a PCB MUST:


### PR DESCRIPTION
Resolves #182 
[Diff with main](https://author-tools.ietf.org/api/iddiff?url_1=https://scionassociation.github.io/scion-cp_I-D/draft-dekater-scion-controlplane.txt&url_2=https://scionassociation.github.io/scion-cp_I-D/scmp-spec/draft-dekater-scion-controlplane.txt) 

Rework of #184 