### PR TITLE
MAC algorithm - mention it in configuration section

### DIFF
--- a/draft-dekater-scion-controlplane.md
+++ b/draft-dekater-scion-controlplane.md
@@ -1080,14 +1080,14 @@ For the purpose of validation, a hop is considered expired if its absolute expir
 
 ### Configuration {#configuration}
 
-For the purpose of constructing and propagating path segments, an AS Control Service must be configured with links to neighboring ASes. Such information may be conveyed to the Control Service in an out-of-band fashion (e.g. in a configuration file). For each link, these values MUST be configured:
+For the purpose of constructing and propagating path segments, a network operator needs to configure an AS Control Service with links to neighboring ASes. Such information may be conveyed to the Control Service in an out-of-band fashion (e.g. in a configuration file). For each link, these values MUST be configured:
 
 - Local Interface ID. This MUST be unique within each AS.
 - Neighbor type (core, parent, child, peer), depending on link type (see [](#paths-links)). Link type depends on mutual agreements between the organizations operating the ASes at each end of each link.
 - Neighbor ISD-AS number
 - Neighbor interface underlay address
 
-In addition, an AS Control Service must be configured with the algorithm used to compute the Hop Field MAC ([](#hopfield)) which is also used by routers within the AS.
+In addition, a network operator needs to configure an AS Control Service with the algorithm and forwarding key used to compute the Hop Field MAC, which are also used by routers within the AS. These are further described in {{I-D.dekater-scion-dataplane}}.
 The maximum MTU supported by all intra-AS links may also be configured by the operator.
 
 
@@ -2368,7 +2368,7 @@ Changes made to drafts since ISE submission. This section is to be removed befor
 - Section 1.7.  Communication Protocol: Clarify DNS resolution is not needed
 - Figures 2, 3, 4: improve arrows in SVG version
 - PCB Extensions: clarify behavior in case of unknown extensions
-- Configuration: mention MAC algorithm as a configuration item
+- Configuration: mention MAC algorithm and forwarding key as a configuration item
 - Timestaps: add normative reference to POSIX.1-2024 to clarify counting of leap seconds
 - Path Lookup Process: reformat and reword steps to clarify how an endpoint requests path segments
 - SCMP: remove experimental values from table and mention more error messages are in referenced spec


### PR DESCRIPTION
An ISE comment in https://github.com/scionassociation/scion-dp_I-D/issues/132 made me realize that we do mention in CP that the MAC algorithm has to be configured, but we forgot to mention it in the configuration section. This PR mentions it in that section too.

[Diff with main](https://author-tools.ietf.org/api/iddiff?url_1=https://scionassociation.github.io/scion-cp_I-D/draft-dekater-scion-controlplane.txt&url_2=https://scionassociation.github.io/scion-cp_I-D/mac_algo_config/draft-dekater-scion-controlplane.txt)
