### PR TITLE
Remove Leaf ASes

### DIFF
--- a/draft-dekater-scion-controlplane.md
+++ b/draft-dekater-scion-controlplane.md
@@ -2036,7 +2036,7 @@ To achieve scalability, SCION ASes are partitioned into ISDs and in an ideal top
 
 In the intra-ISD beaconing, PCBs are propagated top down along parent-child links from core to downstream ASes. Each AS discovers path segments from itself to the core ASes of its ISD.
 
-This produces an acyclic graph which is typically narrow at the top, widens towards the downstream ASes, and is relatively shallow. Intermediate provider ASes will typically have a large number of children whilst only having a small number of parents. Therefore the chain of intermediate providers from a downstream AS to a core AS is typically not long (e.g. local, regional, national provider, then core).
+This produces an acyclic graph which is typically narrow at the top, widens towards downstream ASes, and is relatively shallow. Intermediate provider ASes will typically have a large number of children whilst only having a small number of parents. Therefore the chain of intermediate providers from a downstream AS to a core AS is typically not long (e.g. local, regional, national provider, then core).
 
 Each AS potentially receives PCBs for all down path segments from the core to itself. While the number of distinct provider chains to the core is typically moderate, the multiplicity of links between provider ASes has multiplicative effect on the number of PCBs. Once this number grows above the maximum recommended best PCB set size of 50, ASes SHOULD trim the set of PCBs propagated.
 


### PR DESCRIPTION
The term `leaf-AS` is hardly used in the document and it seems weird that it deserves its own definition.

I propose to remove it from the terminology section.

This PR also removes it from the rest of the document, but it could be left in place. When talking about graphs in computer science, the term "leaf" should probably not require a definition?