### PR TITLE
minor editing pass

### DIFF
--- a/draft-dekater-scion-controlplane.md
+++ b/draft-dekater-scion-controlplane.md
@@ -623,7 +623,7 @@ The PCB top level Protobuf message format is:
 ~~~
 
 - `segment_info`: This field is used as input for the PCB signature. It is the encoded version of the `SegmentInformation` component which provides basic information about the PCB. This component is specified in detail in [](#seginfo).
-- `as_entries`: Contains the `ASEntry` component of all ASes on the path segment represented by this PCB. The order of the AS entries MUST correspond to the path traversal order.
+- `as_entries`: Contains the `ASEntry` component of all ASes on the path segment represented by this PCB. The order of the AS entries MUST correspond to the path traversal order in the PCB propagation direction.
 - `ASEntry`: The `ASEntry` component contains the complete path information of a specific AS that is part of the path segment represented by the PCB. This component is specified in detail in [](#as-entry).
 
 The information to be included in each of these fields is described below.
@@ -1538,7 +1538,7 @@ When the segment request handler of a *core AS* Control Service receives a path 
 
 The Control Plane RPC APIs rely on QUIC connections over UDP/SCION (see {{I-D.dekater-scion-dataplane}}. Establishing such connection requires the initiator to identify the relevant peer (service resolution) and to select a path to it. Since the Control Service is itself the source of path segment information, the following bootstrapping processes apply:
 
-* Neighboring ASes communicate using one-hop paths, as described in {{I-D.dekater-scion-dataplane}}.
+* Neighboring ASes communicate using one-hop paths, as described in {{I-D.dekater-scion-dataplane}}. Core ASes leverage this mechanism when originating new PCBs.
 * Paths to non-neighboring ASes are discovered and constructed incrementally by propagating beacons received from neighbors via these one-hop paths.
 * The resulting multi-hop path segments are registered with the Control Service of the origin Core AS (see {{intra-reg}}).
 * Control Services respond to requests from remote ASes by reversing the path carried in the request packet.


### PR DESCRIPTION
- Reworded the control service bootstrapping process
- Made usage of `Control Service` (instead of `control service`) consistent
- Other minor wording changes.