### PR TITLE
Clarify SCMP processing (second PR)

### DIFF
--- a/draft-dekater-scion-controlplane.md
+++ b/draft-dekater-scion-controlplane.md
@@ -1832,7 +1832,7 @@ AS.
 | Data         | Variable length of arbitrary data                             |
 {: title="Informational Message field values"}
 
-Every node SHOULD implement a SCMP Echo responder function that receives Echo Requests on the default underlay port and originates corresponding Echo replies.
+Every node SHOULD implement a SCMP Echo responder function that receives Echo Requests and originates corresponding Echo replies.
 
 ### Echo Reply {#echo-reply}
 


### PR DESCRIPTION
Includes commits that were in #217 

[Diff with main](https://author-tools.ietf.org/api/iddiff?url_1=https://scionassociation.github.io/scion-cp_I-D/draft-dekater-scion-controlplane.txt&url_2=https://scionassociation.github.io/scion-cp_I-D/tz-scmp/draft-dekater-scion-controlplane.txt)
[Diff with last submission](https://author-tools.ietf.org/api/iddiff?doc_1=draft-dekater-scion-controlplane&url_2=https://scionassociation.github.io/scion-cp_I-D/tz-scmp/draft-dekater-scion-controlplane.txt)